### PR TITLE
Extract generator into separate library

### DIFF
--- a/restdocs-openapi-generator/build.gradle.kts
+++ b/restdocs-openapi-generator/build.gradle.kts
@@ -1,0 +1,30 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    mavenCentral()
+    jcenter()
+    maven { url = uri("https://jitpack.io") }
+}
+
+dependencies {
+    compile(kotlin("stdlib-jdk8"))
+
+    compile("io.swagger:swagger-core:1.5.20")
+    compile("com.fasterxml.jackson.core:jackson-databind:2.9.5")
+    compile("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.5")
+    compile("com.github.everit-org.json-schema:org.everit.json.schema:1.9.1")
+
+    testImplementation("io.swagger:swagger-parser:1.0.36")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.2.0")
+    testImplementation("org.assertj:assertj-core:3.10.0")
+
+    testImplementation("org.amshove.kluent:kluent:1.35")
+    testImplementation("com.jayway.jsonpath:json-path:2.4.0")
+    testImplementation("com.github.java-json-tools:json-schema-validator:2.2.10")
+}
+
+

--- a/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/ApiSpecificationWriter.kt
+++ b/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/ApiSpecificationWriter.kt
@@ -1,11 +1,11 @@
-package com.epages.restdocs.openapi.gradle
+package com.epages.restdocs.openapi.generator
 
 import io.swagger.models.Swagger
 import io.swagger.util.Json
 import io.swagger.util.Yaml
 import java.io.File
 
-internal object ApiSpecificationWriter {
+object ApiSpecificationWriter {
 
     private val yamlFormats = setOf("yaml", "yml")
     private val jsonFormats = setOf("json")

--- a/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/Oauth2Configuration.kt
+++ b/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/Oauth2Configuration.kt
@@ -1,0 +1,13 @@
+package com.epages.restdocs.openapi.generator
+
+import java.io.File
+
+class Oauth2Configuration(
+    var tokenUrl: String = "", // required for types "password", "application", "accessCode"
+    var authorizationUrl: String = "", // required for the "accessCode" type
+    var flows: Array<String> = arrayOf(),
+    var scopeDescriptionsPropertiesFile: String? = null,
+    var scopeDescriptionsPropertiesProjectFile: File? = null
+) {
+    fun securitySchemeName(flow: String) = "oauth2_$flow"
+}

--- a/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/OpenApi20Generator.kt
+++ b/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/OpenApi20Generator.kt
@@ -1,6 +1,6 @@
-package com.epages.restdocs.openapi.gradle
+package com.epages.restdocs.openapi.generator
 
-import com.epages.restdocs.openapi.gradle.schema.JsonSchemaFromFieldDescriptorsGenerator
+import com.epages.restdocs.openapi.generator.schema.JsonSchemaFromFieldDescriptorsGenerator
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -24,7 +24,7 @@ import io.swagger.util.Json
 import java.util.Comparator.comparing
 import java.util.Comparator.comparingInt
 
-internal object OpenApi20Generator {
+object OpenApi20Generator {
 
     private val objectMapper = ObjectMapper(YAMLFactory())
 

--- a/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/ResourceModel.kt
+++ b/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/ResourceModel.kt
@@ -1,6 +1,6 @@
-package com.epages.restdocs.openapi.gradle
+package com.epages.restdocs.openapi.generator
 
-internal data class ResourceModel(
+data class ResourceModel(
     val operationId: String,
     val summary: String? = null,
     val description: String? = null,
@@ -10,7 +10,7 @@ internal data class ResourceModel(
     val response: ResponseModel
 )
 
-internal data class RequestModel(
+data class RequestModel(
     val path: String,
     val method: HTTPMethod,
     val contentType: String? = null,
@@ -23,7 +23,7 @@ internal data class RequestModel(
     val schema: String? = null
 )
 
-internal data class ResponseModel(
+data class ResponseModel(
     val status: Int,
     val contentType: String?,
     val headers: List<HeaderDescriptor>,
@@ -32,7 +32,7 @@ internal data class ResponseModel(
     val schema: String? = null
 )
 
-internal enum class SimpleType {
+enum class SimpleType {
     STRING,
     INTEGER,
     NUMBER,
@@ -46,14 +46,14 @@ interface AbstractParameterDescriptor {
     val optional: Boolean
 }
 
-internal data class HeaderDescriptor(
+data class HeaderDescriptor(
     override val name: String,
     override val description: String,
     override val type: String,
     override val optional: Boolean
 ) : AbstractParameterDescriptor
 
-internal open class FieldDescriptor(
+open class FieldDescriptor(
     val path: String,
     val description: String,
     val type: String,
@@ -62,16 +62,16 @@ internal open class FieldDescriptor(
     val attributes: Attributes = Attributes()
 )
 
-internal data class Attributes(
+data class Attributes(
     val validationConstraints: List<Constraint> = emptyList()
 )
 
-internal data class Constraint(
+data class Constraint(
     val name: String,
     val configuration: Map<String, Any>
 )
 
-internal data class ParameterDescriptor(
+data class ParameterDescriptor(
     override val name: String,
     override val description: String,
     override val type: String,
@@ -79,18 +79,18 @@ internal data class ParameterDescriptor(
     val ignored: Boolean
 ) : AbstractParameterDescriptor
 
-internal data class SecurityRequirements(
+data class SecurityRequirements(
     val type: SecurityType,
     val requiredScopes: List<String>?
 )
 
-internal enum class SecurityType {
+enum class SecurityType {
     OAUTH2,
     BASIC,
     API_KEY
 }
 
-internal enum class HTTPMethod {
+enum class HTTPMethod {
     GET,
     POST,
     PUT,

--- a/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/schema/ConstraintResolver.kt
+++ b/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/schema/ConstraintResolver.kt
@@ -1,7 +1,4 @@
-package com.epages.restdocs.openapi.gradle.schema
-
-import com.epages.restdocs.openapi.gradle.Constraint
-import com.epages.restdocs.openapi.gradle.FieldDescriptor
+package com.epages.restdocs.openapi.generator.schema
 
 internal object ConstraintResolver {
 
@@ -22,7 +19,7 @@ internal object ConstraintResolver {
 
     private const val LENGTH_CONSTRAINT = "org.hibernate.validator.constraints.Length"
 
-    internal fun minLengthString(fieldDescriptor: com.epages.restdocs.openapi.gradle.FieldDescriptor): Int? {
+    internal fun minLengthString(fieldDescriptor: com.epages.restdocs.openapi.generator.FieldDescriptor): Int? {
         return findConstraints(fieldDescriptor)
             .firstOrNull { constraint ->
             (NOT_EMPTY_CONSTRAINTS.contains(constraint.name) ||
@@ -32,16 +29,16 @@ internal object ConstraintResolver {
             ?.let { constraint -> if (LENGTH_CONSTRAINT == constraint.name) constraint.configuration["min"] as Int else 1 }
     }
 
-    internal fun maxLengthString(fieldDescriptor: com.epages.restdocs.openapi.gradle.FieldDescriptor): Int? {
+    internal fun maxLengthString(fieldDescriptor: com.epages.restdocs.openapi.generator.FieldDescriptor): Int? {
         return findConstraints(fieldDescriptor)
             .firstOrNull { LENGTH_CONSTRAINT == it.name }
             ?.let { it.configuration["max"] as Int }
     }
 
-    internal fun isRequired(fieldDescriptor: com.epages.restdocs.openapi.gradle.FieldDescriptor): Boolean =
+    internal fun isRequired(fieldDescriptor: com.epages.restdocs.openapi.generator.FieldDescriptor): Boolean =
         findConstraints(fieldDescriptor)
             .any { constraint -> REQUIRED_CONSTRAINTS.contains(constraint.name) }
 
-    private fun findConstraints(fieldDescriptor: com.epages.restdocs.openapi.gradle.FieldDescriptor): List<com.epages.restdocs.openapi.gradle.Constraint> =
+    private fun findConstraints(fieldDescriptor: com.epages.restdocs.openapi.generator.FieldDescriptor): List<com.epages.restdocs.openapi.generator.Constraint> =
         fieldDescriptor.attributes.validationConstraints
 }

--- a/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/schema/JsonFieldPath.kt
+++ b/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/schema/JsonFieldPath.kt
@@ -1,12 +1,11 @@
-package com.epages.restdocs.openapi.gradle.schema
+package com.epages.restdocs.openapi.generator.schema
 
-import com.epages.restdocs.openapi.gradle.schema.JsonSchemaFromFieldDescriptorsGenerator.FieldDescriptorWithSchemaType
 import java.util.ArrayList
 import java.util.regex.Pattern
 
 internal class JsonFieldPath private constructor(
     private val segments: List<String>,
-    val fieldDescriptor: FieldDescriptorWithSchemaType
+    val fieldDescriptor: JsonSchemaFromFieldDescriptorsGenerator.FieldDescriptorWithSchemaType
 ) {
 
     fun remainingSegments(traversedSegments: List<String>): List<String> {
@@ -31,7 +30,7 @@ internal class JsonFieldPath private constructor(
         private val ARRAY_INDEX_PATTERN = Pattern
             .compile("\\[([0-9]+|\\*){0,1}\\]")
 
-        fun compile(descriptor: FieldDescriptorWithSchemaType): JsonFieldPath {
+        fun compile(descriptor: JsonSchemaFromFieldDescriptorsGenerator.FieldDescriptorWithSchemaType): JsonFieldPath {
             val segments = extractSegments(descriptor.path)
             return JsonFieldPath(segments, descriptor)
         }

--- a/restdocs-openapi-generator/src/test/kotlin/com/epages/restdocs/openapi/generator/OpenApi20GeneratorTest.kt
+++ b/restdocs-openapi-generator/src/test/kotlin/com/epages/restdocs/openapi/generator/OpenApi20GeneratorTest.kt
@@ -1,6 +1,6 @@
-package com.epages.restdocs.openapi.gradle
+package com.epages.restdocs.openapi.generator
 
-import com.epages.restdocs.openapi.gradle.SecurityType.OAUTH2
+import com.epages.restdocs.openapi.generator.SecurityType.OAUTH2
 import io.swagger.models.Model
 import io.swagger.models.Path
 import io.swagger.models.Response

--- a/restdocs-openapi-generator/src/test/kotlin/com/epages/restdocs/openapi/generator/schema/JsonFieldPathTest.kt
+++ b/restdocs-openapi-generator/src/test/kotlin/com/epages/restdocs/openapi/generator/schema/JsonFieldPathTest.kt
@@ -1,7 +1,6 @@
-package com.epages.restdocs.openapi.gradle.schema
+package com.epages.restdocs.openapi.generator.schema
 
-import com.epages.restdocs.openapi.gradle.Attributes
-import com.epages.restdocs.openapi.gradle.schema.JsonFieldPath.Companion.compile
+import com.epages.restdocs.openapi.generator.schema.JsonFieldPath.Companion.compile
 import com.google.common.collect.ImmutableList
 import org.assertj.core.api.BDDAssertions.then
 import org.junit.jupiter.api.Test
@@ -12,8 +11,8 @@ class JsonFieldPathTest {
     @Test
     fun should_get_remaining_segments() {
         with(compile(
-            com.epages.restdocs.openapi.gradle.schema.JsonSchemaFromFieldDescriptorsGenerator.FieldDescriptorWithSchemaType("a.b.c", "", "", false, false,
-                com.epages.restdocs.openapi.gradle.Attributes()
+            com.epages.restdocs.openapi.generator.schema.JsonSchemaFromFieldDescriptorsGenerator.FieldDescriptorWithSchemaType("a.b.c", "", "", false, false,
+                com.epages.restdocs.openapi.generator.Attributes()
             ))) {
             then(remainingSegments(ImmutableList.of("a"))).contains("b", "c")
             then(remainingSegments(ImmutableList.of("a", "b"))).contains("c")

--- a/restdocs-openapi-generator/src/test/kotlin/com/epages/restdocs/openapi/generator/schema/JsonSchemaFromFieldDescriptorsGeneratorTest.kt
+++ b/restdocs-openapi-generator/src/test/kotlin/com/epages/restdocs/openapi/generator/schema/JsonSchemaFromFieldDescriptorsGeneratorTest.kt
@@ -1,8 +1,5 @@
-package com.epages.restdocs.openapi.gradle.schema
+package com.epages.restdocs.openapi.generator.schema
 
-import com.epages.restdocs.openapi.gradle.Attributes
-import com.epages.restdocs.openapi.gradle.Constraint
-import com.epages.restdocs.openapi.gradle.FieldDescriptor
 import com.github.fge.jackson.JsonLoader
 import com.github.fge.jsonschema.main.JsonSchemaFactory
 import com.jayway.jsonpath.JsonPath
@@ -23,11 +20,11 @@ import javax.validation.constraints.NotNull
 
 class JsonSchemaFromFieldDescriptorsGeneratorTest {
 
-    private val generator = com.epages.restdocs.openapi.gradle.schema.JsonSchemaFromFieldDescriptorsGenerator()
+    private val generator = com.epages.restdocs.openapi.generator.schema.JsonSchemaFromFieldDescriptorsGenerator()
 
     private var schema: Schema? = null
 
-    private var fieldDescriptors: List<com.epages.restdocs.openapi.gradle.FieldDescriptor>? = null
+    private var fieldDescriptors: List<com.epages.restdocs.openapi.generator.FieldDescriptor>? = null
 
     private var schemaString: String? = null
 
@@ -198,45 +195,45 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
     }
 
     private fun givenFieldDescriptorWithPrimitiveArray() {
-        fieldDescriptors = listOf(com.epages.restdocs.openapi.gradle.FieldDescriptor("a[]", "some", "ARRAY"))
+        fieldDescriptors = listOf(com.epages.restdocs.openapi.generator.FieldDescriptor("a[]", "some", "ARRAY"))
     }
 
     private fun givenFieldDescriptorWithTopLevelArray() {
-        fieldDescriptors = listOf(com.epages.restdocs.openapi.gradle.FieldDescriptor("[]['id']", "some", "STRING"))
+        fieldDescriptors = listOf(com.epages.restdocs.openapi.generator.FieldDescriptor("[]['id']", "some", "STRING"))
     }
 
     private fun givenFieldDescriptorWithTopLevelArrayOfAny() {
-        fieldDescriptors = listOf(com.epages.restdocs.openapi.gradle.FieldDescriptor("[]", "some", "ARRAY"))
+        fieldDescriptors = listOf(com.epages.restdocs.openapi.generator.FieldDescriptor("[]", "some", "ARRAY"))
     }
 
     private fun givenFieldDescriptorWithTopLevelArrayOfArrayOfAny() {
-        fieldDescriptors = listOf(com.epages.restdocs.openapi.gradle.FieldDescriptor("[][]", "some", "ARRAY"))
+        fieldDescriptors = listOf(com.epages.restdocs.openapi.generator.FieldDescriptor("[][]", "some", "ARRAY"))
     }
 
     private fun givenFieldDescriptorWithInvalidType() {
-        fieldDescriptors = listOf(com.epages.restdocs.openapi.gradle.FieldDescriptor("id", "some", "invalid-type"))
+        fieldDescriptors = listOf(com.epages.restdocs.openapi.generator.FieldDescriptor("id", "some", "invalid-type"))
     }
 
     private fun givenEqualFieldDescriptorsWithSamePath() {
         fieldDescriptors = listOf(
-            com.epages.restdocs.openapi.gradle.FieldDescriptor("id", "some", "STRING"),
-            com.epages.restdocs.openapi.gradle.FieldDescriptor("id", "some", "STRING")
+            com.epages.restdocs.openapi.generator.FieldDescriptor("id", "some", "STRING"),
+            com.epages.restdocs.openapi.generator.FieldDescriptor("id", "some", "STRING")
         )
     }
 
     private fun givenDifferentFieldDescriptorsWithSamePathAndDifferentTypes() {
         fieldDescriptors = listOf(
-            com.epages.restdocs.openapi.gradle.FieldDescriptor("id", "some", "STRING"),
-            com.epages.restdocs.openapi.gradle.FieldDescriptor("id", "some", "NULL"),
-            com.epages.restdocs.openapi.gradle.FieldDescriptor("id", "some", "BOOLEAN")
+            com.epages.restdocs.openapi.generator.FieldDescriptor("id", "some", "STRING"),
+            com.epages.restdocs.openapi.generator.FieldDescriptor("id", "some", "NULL"),
+            com.epages.restdocs.openapi.generator.FieldDescriptor("id", "some", "BOOLEAN")
         )
     }
 
     private fun givenFieldDescriptorsWithConstraints() {
         val constraintAttributeWithNotNull =
-            com.epages.restdocs.openapi.gradle.Attributes(
+            com.epages.restdocs.openapi.generator.Attributes(
                 listOf(
-                    com.epages.restdocs.openapi.gradle.Constraint(
+                    com.epages.restdocs.openapi.generator.Constraint(
                         NotNull::class.java.name,
                         emptyMap()
                     )
@@ -244,9 +241,9 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
             )
 
         val constraintAttributeWithLength =
-            com.epages.restdocs.openapi.gradle.Attributes(
+            com.epages.restdocs.openapi.generator.Attributes(
                 listOf(
-                    com.epages.restdocs.openapi.gradle.Constraint(
+                    com.epages.restdocs.openapi.generator.Constraint(
                         "org.hibernate.validator.constraints.Length", mapOf(
                             "min" to 2,
                             "max" to 255
@@ -256,46 +253,46 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
             )
 
         fieldDescriptors = listOf(
-            com.epages.restdocs.openapi.gradle.FieldDescriptor(
+            com.epages.restdocs.openapi.generator.FieldDescriptor(
                 "id",
                 "some",
                 "STRING",
                 attributes = constraintAttributeWithNotNull
             ),
-            com.epages.restdocs.openapi.gradle.FieldDescriptor(
+            com.epages.restdocs.openapi.generator.FieldDescriptor(
                 "lineItems[*].name",
                 "some",
                 "STRING",
                 attributes = constraintAttributeWithLength
             ),
-            com.epages.restdocs.openapi.gradle.FieldDescriptor(
+            com.epages.restdocs.openapi.generator.FieldDescriptor(
                 "lineItems[*]._id",
                 "some",
                 "STRING",
                 attributes = constraintAttributeWithNotNull
             ),
-            com.epages.restdocs.openapi.gradle.FieldDescriptor(
+            com.epages.restdocs.openapi.generator.FieldDescriptor(
                 "lineItems[*].quantity.value",
                 "some",
                 "NUMBER",
                 attributes = constraintAttributeWithNotNull
             ),
-            com.epages.restdocs.openapi.gradle.FieldDescriptor("lineItems[*].quantity.unit", "some", "STRING"),
-            com.epages.restdocs.openapi.gradle.FieldDescriptor("shippingAddress", "some", "OBJECT"),
-            com.epages.restdocs.openapi.gradle.FieldDescriptor("billingAddress", "some", "OBJECT"),
-            com.epages.restdocs.openapi.gradle.FieldDescriptor(
+            com.epages.restdocs.openapi.generator.FieldDescriptor("lineItems[*].quantity.unit", "some", "STRING"),
+            com.epages.restdocs.openapi.generator.FieldDescriptor("shippingAddress", "some", "OBJECT"),
+            com.epages.restdocs.openapi.generator.FieldDescriptor("billingAddress", "some", "OBJECT"),
+            com.epages.restdocs.openapi.generator.FieldDescriptor(
                 "billingAddress.firstName", "some", "STRING",
-                attributes = com.epages.restdocs.openapi.gradle.Attributes(
+                attributes = com.epages.restdocs.openapi.generator.Attributes(
                     listOf(
-                        com.epages.restdocs.openapi.gradle.Constraint(
+                        com.epages.restdocs.openapi.generator.Constraint(
                             "javax.validation.constraints.NotEmpty",
                             emptyMap()
                         )
                     )
                 )
             ),
-            com.epages.restdocs.openapi.gradle.FieldDescriptor("billingAddress.valid", "some", "BOOLEAN"),
-            com.epages.restdocs.openapi.gradle.FieldDescriptor("paymentLineItem.lineItemTaxes", "some", "ARRAY")
+            com.epages.restdocs.openapi.generator.FieldDescriptor("billingAddress.valid", "some", "BOOLEAN"),
+            com.epages.restdocs.openapi.generator.FieldDescriptor("paymentLineItem.lineItemTaxes", "some", "ARRAY")
         )
     }
 

--- a/restdocs-openapi-gradle-plugin/build.gradle.kts
+++ b/restdocs-openapi-gradle-plugin/build.gradle.kts
@@ -29,19 +29,15 @@ dependencies {
     compile(kotlin("gradle-plugin"))
     compile(kotlin("stdlib-jdk8"))
 
-    implementation("io.swagger:swagger-core:1.5.20")
+    implementation(project(":restdocs-openapi-generator"))
     implementation("com.fasterxml.jackson.core:jackson-databind:2.9.5")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.5")
-    implementation("com.github.everit-org.json-schema:org.everit.json.schema:1.9.1")
 
-    testImplementation("io.swagger:swagger-parser:1.0.36")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.2.0")
     testImplementation("org.assertj:assertj-core:3.10.0")
 
     testImplementation("org.amshove.kluent:kluent:1.35")
     testImplementation("com.jayway.jsonpath:json-path:2.4.0")
-    testImplementation("com.github.java-json-tools:json-schema-validator:2.2.10")
-
 
     testCompile(gradleTestKit())
 }

--- a/restdocs-openapi-gradle-plugin/src/main/kotlin/com/epages/restdocs/openapi/gradle/RestdocsOpenApiPluginExtension.kt
+++ b/restdocs-openapi-gradle-plugin/src/main/kotlin/com/epages/restdocs/openapi/gradle/RestdocsOpenApiPluginExtension.kt
@@ -1,8 +1,8 @@
 package com.epages.restdocs.openapi.gradle
 
+import com.epages.restdocs.openapi.generator.Oauth2Configuration
 import groovy.lang.Closure
 import org.gradle.api.Project
-import java.io.File
 
 open class RestdocsOpenApiPluginExtension(val project: Project) {
     var host: String = "localhost"
@@ -32,16 +32,4 @@ open class RestdocsOpenApiPluginExtension(val project: Project) {
             }
         }
     }
-}
-
-class Oauth2Configuration(
-    var tokenUrl: String = "", // required for types "password", "application", "accessCode"
-    var authorizationUrl: String = "", // required for the "accessCode" type
-    var flows: Array<String> = arrayOf(),
-    var scopeDescriptionsPropertiesFile: String? = null
-) {
-    internal var
-        scopeDescriptionsPropertiesProjectFile: File? = null
-
-    fun securitySchemeName(flow: String) = "oauth2_$flow"
 }

--- a/restdocs-openapi-gradle-plugin/src/main/kotlin/com/epages/restdocs/openapi/gradle/RestdocsOpenApiTask.kt
+++ b/restdocs-openapi-gradle-plugin/src/main/kotlin/com/epages/restdocs/openapi/gradle/RestdocsOpenApiTask.kt
@@ -1,5 +1,9 @@
 package com.epages.restdocs.openapi.gradle
 
+import com.epages.restdocs.openapi.generator.ApiSpecificationWriter
+import com.epages.restdocs.openapi.generator.Oauth2Configuration
+import com.epages.restdocs.openapi.generator.OpenApi20Generator
+import com.epages.restdocs.openapi.generator.ResourceModel
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = 'restdocs-openapi-parent'
 include 'restdocs-openapi'
+include 'restdocs-openapi-generator'
 include 'restdocs-openapi-gradle-plugin'
 include 'restdocs-openapi-sample'
 project(':restdocs-openapi-sample').projectDir = file('samples/restdocs-openapi-sample')


### PR DESCRIPTION
I've moved everything unrelated to the gradle plugin into a separate library called "restdocs-openapi-generator".  This should allow the maven plugin to take advantage of the same code as the gradle plugin.

I'm not a gradle expert so I might not quite have the `build.gradle.kts` files correct.  Let me know if I should change anything there.