### PR TITLE
Add attributes property to AbstractParameterDescriptor

### DIFF
--- a/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/ResourceModel.kt
+++ b/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/ResourceModel.kt
@@ -44,13 +44,15 @@ interface AbstractParameterDescriptor {
     val description: String
     val type: String
     val optional: Boolean
+    val attributes: Attributes
 }
 
 data class HeaderDescriptor(
     override val name: String,
     override val description: String,
     override val type: String,
-    override val optional: Boolean
+    override val optional: Boolean,
+    override val attributes: Attributes = Attributes()
 ) : AbstractParameterDescriptor
 
 open class FieldDescriptor(
@@ -76,7 +78,8 @@ data class ParameterDescriptor(
     override val description: String,
     override val type: String,
     override val optional: Boolean,
-    val ignored: Boolean
+    val ignored: Boolean,
+    override val attributes: Attributes = Attributes()
 ) : AbstractParameterDescriptor
 
 data class SecurityRequirements(


### PR DESCRIPTION
The `org.springframework.restdocs.snippet.AbstractDescriptor` class has an `attributes` property and both `org.springframework.restdocs.request.ParameterDescriptor` and `org.springframework.restdocs.headers.HeaderDescriptor` extend from it.  Changing the `AbstractParameterDescriptor` in `restdocs-openapi-generator` to also have the `attributes` property to match.