### PR TITLE
Move reading of scopes yaml file out of generator

### DIFF
--- a/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/Oauth2Configuration.kt
+++ b/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/Oauth2Configuration.kt
@@ -1,13 +1,10 @@
 package com.epages.restdocs.openapi.generator
 
-import java.io.File
-
-class Oauth2Configuration(
+open class Oauth2Configuration(
     var tokenUrl: String = "", // required for types "password", "application", "accessCode"
     var authorizationUrl: String = "", // required for the "accessCode" type
     var flows: Array<String> = arrayOf(),
-    var scopeDescriptionsPropertiesFile: String? = null,
-    var scopeDescriptionsPropertiesProjectFile: File? = null
+    var scopes: Map<String, String> = mapOf()
 ) {
     fun securitySchemeName(flow: String) = "oauth2_$flow"
 }

--- a/restdocs-openapi-gradle-plugin/src/main/kotlin/com/epages/restdocs/openapi/gradle/RestdocsOpenApiPluginExtension.kt
+++ b/restdocs-openapi-gradle-plugin/src/main/kotlin/com/epages/restdocs/openapi/gradle/RestdocsOpenApiPluginExtension.kt
@@ -1,10 +1,17 @@
 package com.epages.restdocs.openapi.gradle
 
 import com.epages.restdocs.openapi.generator.Oauth2Configuration
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.readValue
 import groovy.lang.Closure
 import org.gradle.api.Project
+import java.io.File
 
 open class RestdocsOpenApiPluginExtension(val project: Project) {
+
+    private val objectMapper = ObjectMapper(YAMLFactory())
+
     var host: String = "localhost"
     var basePath: String? = null
     var schemes: Array<String> = arrayOf("http")
@@ -16,7 +23,7 @@ open class RestdocsOpenApiPluginExtension(val project: Project) {
 
     var separatePublicApi: Boolean = false
 
-    var oauth2SecuritySchemeDefinition: Oauth2Configuration? = null
+    var oauth2SecuritySchemeDefinition: PluginOauth2Configuration? = null
 
     var outputDirectory = "build/openapi"
     var snippetsDirectory = "build/generated-snippets"
@@ -25,11 +32,19 @@ open class RestdocsOpenApiPluginExtension(val project: Project) {
 
     @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
     fun setOauth2SecuritySchemeDefinition(closure: Closure<*>) {
-        oauth2SecuritySchemeDefinition = project.configure(Oauth2Configuration(), closure) as Oauth2Configuration
+        oauth2SecuritySchemeDefinition = project.configure(PluginOauth2Configuration(), closure) as PluginOauth2Configuration
         with(oauth2SecuritySchemeDefinition!!) {
             if (scopeDescriptionsPropertiesFile != null) {
-                scopeDescriptionsPropertiesProjectFile = project.file(scopeDescriptionsPropertiesFile!!)
+                scopes = scopeDescriptionSource(project.file(scopeDescriptionsPropertiesFile!!))
             }
         }
     }
+
+    private fun scopeDescriptionSource(scopeDescriptionsPropertiesFile: File): Map<String, String> {
+        return scopeDescriptionsPropertiesFile.let { objectMapper.readValue(it) } ?: emptyMap()
+    }
 }
+
+class PluginOauth2Configuration(
+    var scopeDescriptionsPropertiesFile: String? = null
+) : Oauth2Configuration()

--- a/restdocs-openapi-gradle-plugin/src/main/kotlin/com/epages/restdocs/openapi/gradle/RestdocsOpenApiTask.kt
+++ b/restdocs-openapi-gradle-plugin/src/main/kotlin/com/epages/restdocs/openapi/gradle/RestdocsOpenApiTask.kt
@@ -1,7 +1,6 @@
 package com.epages.restdocs.openapi.gradle
 
 import com.epages.restdocs.openapi.generator.ApiSpecificationWriter
-import com.epages.restdocs.openapi.generator.Oauth2Configuration
 import com.epages.restdocs.openapi.generator.OpenApi20Generator
 import com.epages.restdocs.openapi.generator.ResourceModel
 import com.fasterxml.jackson.databind.DeserializationFeature
@@ -45,7 +44,7 @@ open class RestdocsOpenApiTask : DefaultTask() {
     lateinit var outputFileNamePrefix: String
 
     @Input @Optional
-    var oauth2SecuritySchemeDefinition: Oauth2Configuration? = null
+    var oauth2SecuritySchemeDefinition: PluginOauth2Configuration? = null
 
     private val outputDirectoryFile
         get() = project.file(outputDirectory)


### PR DESCRIPTION
Currently, you must provide the generator with a yaml file containing
the scope descriptions and it reads that file.  Having the generator
read from the file system feels out of place since that should really be
the plugins responsibility.

Added a new `scopes` property to `Oauth2Configuration` that will hold a
map of the scopes and descriptions.  The plugin now reads in the yaml
file and populates this new `scopes` property instead of just passing
the file to the generator.