### PR TITLE
Move the model into a separate library

### DIFF
--- a/restdocs-openapi-generator/build.gradle.kts
+++ b/restdocs-openapi-generator/build.gradle.kts
@@ -13,6 +13,7 @@ repositories {
 dependencies {
     compile(kotlin("stdlib-jdk8"))
 
+    compile(project(":restdocs-openapi-model"))
     compile("io.swagger:swagger-core:1.5.20")
     compile("com.fasterxml.jackson.core:jackson-databind:2.9.5")
     compile("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.5")

--- a/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/OpenApi20Generator.kt
+++ b/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/OpenApi20Generator.kt
@@ -1,6 +1,15 @@
 package com.epages.restdocs.openapi.generator
 
 import com.epages.restdocs.openapi.generator.schema.JsonSchemaFromFieldDescriptorsGenerator
+import com.epages.restdocs.openapi.model.FieldDescriptor
+import com.epages.restdocs.openapi.model.HTTPMethod
+import com.epages.restdocs.openapi.model.HeaderDescriptor
+import com.epages.restdocs.openapi.model.Oauth2Configuration
+import com.epages.restdocs.openapi.model.ParameterDescriptor
+import com.epages.restdocs.openapi.model.ResourceModel
+import com.epages.restdocs.openapi.model.ResponseModel
+import com.epages.restdocs.openapi.model.SecurityRequirements
+import com.epages.restdocs.openapi.model.SecurityType
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.swagger.models.Info
 import io.swagger.models.Model
@@ -196,10 +205,10 @@ object OpenApi20Generator {
                     .nullIfEmpty()
         }.apply {
             if (firstModelForPathAndMethod.request.securityRequirements != null &&
-                firstModelForPathAndMethod.request.securityRequirements.type == SecurityType.OAUTH2) {
+                firstModelForPathAndMethod.request.securityRequirements!!.type == SecurityType.OAUTH2) {
                 oauth2SecuritySchemeDefinition?.flows?.map {
                     addSecurity(oauth2SecuritySchemeDefinition.securitySchemeName(it),
-                        securityRequirements2ScopesList(firstModelForPathAndMethod.request.securityRequirements))
+                        securityRequirements2ScopesList(firstModelForPathAndMethod.request.securityRequirements!!))
                 }
             }
         }
@@ -221,7 +230,7 @@ object OpenApi20Generator {
     }
 
     private fun securityRequirements2ScopesList(securityRequirements: SecurityRequirements): List<String> {
-        return if (securityRequirements.type == SecurityType.OAUTH2 && securityRequirements.requiredScopes != null) securityRequirements.requiredScopes else listOf()
+        return if (securityRequirements.type == SecurityType.OAUTH2 && securityRequirements.requiredScopes != null) securityRequirements.requiredScopes!! else listOf()
     }
 
     private fun addSecurityDefinitions(openApi: Swagger, oauth2SecuritySchemeDefinition: Oauth2Configuration?) {

--- a/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/schema/ConstraintResolver.kt
+++ b/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/schema/ConstraintResolver.kt
@@ -19,7 +19,7 @@ internal object ConstraintResolver {
 
     private const val LENGTH_CONSTRAINT = "org.hibernate.validator.constraints.Length"
 
-    internal fun minLengthString(fieldDescriptor: com.epages.restdocs.openapi.generator.FieldDescriptor): Int? {
+    internal fun minLengthString(fieldDescriptor: com.epages.restdocs.openapi.model.FieldDescriptor): Int? {
         return findConstraints(fieldDescriptor)
             .firstOrNull { constraint ->
             (NOT_EMPTY_CONSTRAINTS.contains(constraint.name) ||
@@ -29,16 +29,16 @@ internal object ConstraintResolver {
             ?.let { constraint -> if (LENGTH_CONSTRAINT == constraint.name) constraint.configuration["min"] as Int else 1 }
     }
 
-    internal fun maxLengthString(fieldDescriptor: com.epages.restdocs.openapi.generator.FieldDescriptor): Int? {
+    internal fun maxLengthString(fieldDescriptor: com.epages.restdocs.openapi.model.FieldDescriptor): Int? {
         return findConstraints(fieldDescriptor)
             .firstOrNull { LENGTH_CONSTRAINT == it.name }
             ?.let { it.configuration["max"] as Int }
     }
 
-    internal fun isRequired(fieldDescriptor: com.epages.restdocs.openapi.generator.FieldDescriptor): Boolean =
+    internal fun isRequired(fieldDescriptor: com.epages.restdocs.openapi.model.FieldDescriptor): Boolean =
         findConstraints(fieldDescriptor)
             .any { constraint -> REQUIRED_CONSTRAINTS.contains(constraint.name) }
 
-    private fun findConstraints(fieldDescriptor: com.epages.restdocs.openapi.generator.FieldDescriptor): List<com.epages.restdocs.openapi.generator.Constraint> =
+    private fun findConstraints(fieldDescriptor: com.epages.restdocs.openapi.model.FieldDescriptor): List<com.epages.restdocs.openapi.model.Constraint> =
         fieldDescriptor.attributes.validationConstraints
 }

--- a/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/schema/JsonSchemaFromFieldDescriptorsGenerator.kt
+++ b/restdocs-openapi-generator/src/main/kotlin/com/epages/restdocs/openapi/generator/schema/JsonSchemaFromFieldDescriptorsGenerator.kt
@@ -22,7 +22,7 @@ import java.util.function.Predicate
 
 internal class JsonSchemaFromFieldDescriptorsGenerator {
 
-    internal fun generateSchema(fieldDescriptors: List<com.epages.restdocs.openapi.generator.FieldDescriptor>, title: String? = null): String {
+    internal fun generateSchema(fieldDescriptors: List<com.epages.restdocs.openapi.model.FieldDescriptor>, title: String? = null): String {
         val jsonFieldPaths = reduceFieldDescriptors(fieldDescriptors)
             .map { com.epages.restdocs.openapi.generator.schema.JsonFieldPath.compile(it) }
 
@@ -36,7 +36,7 @@ internal class JsonSchemaFromFieldDescriptorsGenerator {
      *
      * The implementation will
      */
-    private fun reduceFieldDescriptors(fieldDescriptors: List<com.epages.restdocs.openapi.generator.FieldDescriptor>): List<FieldDescriptorWithSchemaType> {
+    private fun reduceFieldDescriptors(fieldDescriptors: List<com.epages.restdocs.openapi.model.FieldDescriptor>): List<FieldDescriptorWithSchemaType> {
         return fieldDescriptors
             .map { FieldDescriptorWithSchemaType.fromFieldDescriptor(it) }
             .foldRight(listOf()) { fieldDescriptor, groups -> groups
@@ -182,9 +182,9 @@ internal class JsonSchemaFromFieldDescriptorsGenerator {
         type: String,
         optional: Boolean,
         ignored: Boolean,
-        attributes: com.epages.restdocs.openapi.generator.Attributes,
+        attributes: com.epages.restdocs.openapi.model.Attributes,
         private val jsonSchemaPrimitiveTypes: Set<String> = setOf(jsonSchemaPrimitiveTypeFromDescriptorType(type))
-    ) : com.epages.restdocs.openapi.generator.FieldDescriptor(path, description, type, optional, ignored, attributes) {
+    ) : com.epages.restdocs.openapi.model.FieldDescriptor(path, description, type, optional, ignored, attributes) {
 
         fun jsonSchemaType(): Schema {
             val schemaBuilders = jsonSchemaPrimitiveTypes.map { typeToSchema(it) }
@@ -192,7 +192,7 @@ internal class JsonSchemaFromFieldDescriptorsGenerator {
             else CombinedSchema.oneOf(schemaBuilders.map { it.build() }).description(description).build()
         }
 
-        fun merge(fieldDescriptor: com.epages.restdocs.openapi.generator.FieldDescriptor): FieldDescriptorWithSchemaType {
+        fun merge(fieldDescriptor: com.epages.restdocs.openapi.model.FieldDescriptor): FieldDescriptorWithSchemaType {
             if (this.path != fieldDescriptor.path)
                 throw IllegalArgumentException("path of fieldDescriptor is not equal to ${this.path}")
 
@@ -226,7 +226,7 @@ internal class JsonSchemaFromFieldDescriptorsGenerator {
                 this.type == f.type)
 
         companion object {
-            fun fromFieldDescriptor(fieldDescriptor: com.epages.restdocs.openapi.generator.FieldDescriptor) =
+            fun fromFieldDescriptor(fieldDescriptor: com.epages.restdocs.openapi.model.FieldDescriptor) =
                 FieldDescriptorWithSchemaType(
                     path = fieldDescriptor.path,
                     description = fieldDescriptor.description,

--- a/restdocs-openapi-generator/src/test/kotlin/com/epages/restdocs/openapi/generator/OpenApi20GeneratorTest.kt
+++ b/restdocs-openapi-generator/src/test/kotlin/com/epages/restdocs/openapi/generator/OpenApi20GeneratorTest.kt
@@ -1,6 +1,16 @@
 package com.epages.restdocs.openapi.generator
 
-import com.epages.restdocs.openapi.generator.SecurityType.OAUTH2
+import com.epages.restdocs.openapi.model.AbstractParameterDescriptor
+import com.epages.restdocs.openapi.model.FieldDescriptor
+import com.epages.restdocs.openapi.model.HTTPMethod
+import com.epages.restdocs.openapi.model.HeaderDescriptor
+import com.epages.restdocs.openapi.model.Oauth2Configuration
+import com.epages.restdocs.openapi.model.ParameterDescriptor
+import com.epages.restdocs.openapi.model.RequestModel
+import com.epages.restdocs.openapi.model.ResourceModel
+import com.epages.restdocs.openapi.model.ResponseModel
+import com.epages.restdocs.openapi.model.SecurityRequirements
+import com.epages.restdocs.openapi.model.SecurityType.OAUTH2
 import io.swagger.models.Model
 import io.swagger.models.Path
 import io.swagger.models.Response

--- a/restdocs-openapi-generator/src/test/kotlin/com/epages/restdocs/openapi/generator/schema/JsonFieldPathTest.kt
+++ b/restdocs-openapi-generator/src/test/kotlin/com/epages/restdocs/openapi/generator/schema/JsonFieldPathTest.kt
@@ -12,7 +12,7 @@ class JsonFieldPathTest {
     fun should_get_remaining_segments() {
         with(compile(
             com.epages.restdocs.openapi.generator.schema.JsonSchemaFromFieldDescriptorsGenerator.FieldDescriptorWithSchemaType("a.b.c", "", "", false, false,
-                com.epages.restdocs.openapi.generator.Attributes()
+                com.epages.restdocs.openapi.model.Attributes()
             ))) {
             then(remainingSegments(ImmutableList.of("a"))).contains("b", "c")
             then(remainingSegments(ImmutableList.of("a", "b"))).contains("c")

--- a/restdocs-openapi-generator/src/test/kotlin/com/epages/restdocs/openapi/generator/schema/JsonSchemaFromFieldDescriptorsGeneratorTest.kt
+++ b/restdocs-openapi-generator/src/test/kotlin/com/epages/restdocs/openapi/generator/schema/JsonSchemaFromFieldDescriptorsGeneratorTest.kt
@@ -24,7 +24,7 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
 
     private var schema: Schema? = null
 
-    private var fieldDescriptors: List<com.epages.restdocs.openapi.generator.FieldDescriptor>? = null
+    private var fieldDescriptors: List<com.epages.restdocs.openapi.model.FieldDescriptor>? = null
 
     private var schemaString: String? = null
 
@@ -195,45 +195,45 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
     }
 
     private fun givenFieldDescriptorWithPrimitiveArray() {
-        fieldDescriptors = listOf(com.epages.restdocs.openapi.generator.FieldDescriptor("a[]", "some", "ARRAY"))
+        fieldDescriptors = listOf(com.epages.restdocs.openapi.model.FieldDescriptor("a[]", "some", "ARRAY"))
     }
 
     private fun givenFieldDescriptorWithTopLevelArray() {
-        fieldDescriptors = listOf(com.epages.restdocs.openapi.generator.FieldDescriptor("[]['id']", "some", "STRING"))
+        fieldDescriptors = listOf(com.epages.restdocs.openapi.model.FieldDescriptor("[]['id']", "some", "STRING"))
     }
 
     private fun givenFieldDescriptorWithTopLevelArrayOfAny() {
-        fieldDescriptors = listOf(com.epages.restdocs.openapi.generator.FieldDescriptor("[]", "some", "ARRAY"))
+        fieldDescriptors = listOf(com.epages.restdocs.openapi.model.FieldDescriptor("[]", "some", "ARRAY"))
     }
 
     private fun givenFieldDescriptorWithTopLevelArrayOfArrayOfAny() {
-        fieldDescriptors = listOf(com.epages.restdocs.openapi.generator.FieldDescriptor("[][]", "some", "ARRAY"))
+        fieldDescriptors = listOf(com.epages.restdocs.openapi.model.FieldDescriptor("[][]", "some", "ARRAY"))
     }
 
     private fun givenFieldDescriptorWithInvalidType() {
-        fieldDescriptors = listOf(com.epages.restdocs.openapi.generator.FieldDescriptor("id", "some", "invalid-type"))
+        fieldDescriptors = listOf(com.epages.restdocs.openapi.model.FieldDescriptor("id", "some", "invalid-type"))
     }
 
     private fun givenEqualFieldDescriptorsWithSamePath() {
         fieldDescriptors = listOf(
-            com.epages.restdocs.openapi.generator.FieldDescriptor("id", "some", "STRING"),
-            com.epages.restdocs.openapi.generator.FieldDescriptor("id", "some", "STRING")
+            com.epages.restdocs.openapi.model.FieldDescriptor("id", "some", "STRING"),
+            com.epages.restdocs.openapi.model.FieldDescriptor("id", "some", "STRING")
         )
     }
 
     private fun givenDifferentFieldDescriptorsWithSamePathAndDifferentTypes() {
         fieldDescriptors = listOf(
-            com.epages.restdocs.openapi.generator.FieldDescriptor("id", "some", "STRING"),
-            com.epages.restdocs.openapi.generator.FieldDescriptor("id", "some", "NULL"),
-            com.epages.restdocs.openapi.generator.FieldDescriptor("id", "some", "BOOLEAN")
+            com.epages.restdocs.openapi.model.FieldDescriptor("id", "some", "STRING"),
+            com.epages.restdocs.openapi.model.FieldDescriptor("id", "some", "NULL"),
+            com.epages.restdocs.openapi.model.FieldDescriptor("id", "some", "BOOLEAN")
         )
     }
 
     private fun givenFieldDescriptorsWithConstraints() {
         val constraintAttributeWithNotNull =
-            com.epages.restdocs.openapi.generator.Attributes(
+            com.epages.restdocs.openapi.model.Attributes(
                 listOf(
-                    com.epages.restdocs.openapi.generator.Constraint(
+                    com.epages.restdocs.openapi.model.Constraint(
                         NotNull::class.java.name,
                         emptyMap()
                     )
@@ -241,9 +241,9 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
             )
 
         val constraintAttributeWithLength =
-            com.epages.restdocs.openapi.generator.Attributes(
+            com.epages.restdocs.openapi.model.Attributes(
                 listOf(
-                    com.epages.restdocs.openapi.generator.Constraint(
+                    com.epages.restdocs.openapi.model.Constraint(
                         "org.hibernate.validator.constraints.Length", mapOf(
                             "min" to 2,
                             "max" to 255
@@ -253,46 +253,46 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
             )
 
         fieldDescriptors = listOf(
-            com.epages.restdocs.openapi.generator.FieldDescriptor(
+            com.epages.restdocs.openapi.model.FieldDescriptor(
                 "id",
                 "some",
                 "STRING",
                 attributes = constraintAttributeWithNotNull
             ),
-            com.epages.restdocs.openapi.generator.FieldDescriptor(
+            com.epages.restdocs.openapi.model.FieldDescriptor(
                 "lineItems[*].name",
                 "some",
                 "STRING",
                 attributes = constraintAttributeWithLength
             ),
-            com.epages.restdocs.openapi.generator.FieldDescriptor(
+            com.epages.restdocs.openapi.model.FieldDescriptor(
                 "lineItems[*]._id",
                 "some",
                 "STRING",
                 attributes = constraintAttributeWithNotNull
             ),
-            com.epages.restdocs.openapi.generator.FieldDescriptor(
+            com.epages.restdocs.openapi.model.FieldDescriptor(
                 "lineItems[*].quantity.value",
                 "some",
                 "NUMBER",
                 attributes = constraintAttributeWithNotNull
             ),
-            com.epages.restdocs.openapi.generator.FieldDescriptor("lineItems[*].quantity.unit", "some", "STRING"),
-            com.epages.restdocs.openapi.generator.FieldDescriptor("shippingAddress", "some", "OBJECT"),
-            com.epages.restdocs.openapi.generator.FieldDescriptor("billingAddress", "some", "OBJECT"),
-            com.epages.restdocs.openapi.generator.FieldDescriptor(
+            com.epages.restdocs.openapi.model.FieldDescriptor("lineItems[*].quantity.unit", "some", "STRING"),
+            com.epages.restdocs.openapi.model.FieldDescriptor("shippingAddress", "some", "OBJECT"),
+            com.epages.restdocs.openapi.model.FieldDescriptor("billingAddress", "some", "OBJECT"),
+            com.epages.restdocs.openapi.model.FieldDescriptor(
                 "billingAddress.firstName", "some", "STRING",
-                attributes = com.epages.restdocs.openapi.generator.Attributes(
+                attributes = com.epages.restdocs.openapi.model.Attributes(
                     listOf(
-                        com.epages.restdocs.openapi.generator.Constraint(
+                        com.epages.restdocs.openapi.model.Constraint(
                             "javax.validation.constraints.NotEmpty",
                             emptyMap()
                         )
                     )
                 )
             ),
-            com.epages.restdocs.openapi.generator.FieldDescriptor("billingAddress.valid", "some", "BOOLEAN"),
-            com.epages.restdocs.openapi.generator.FieldDescriptor("paymentLineItem.lineItemTaxes", "some", "ARRAY")
+            com.epages.restdocs.openapi.model.FieldDescriptor("billingAddress.valid", "some", "BOOLEAN"),
+            com.epages.restdocs.openapi.model.FieldDescriptor("paymentLineItem.lineItemTaxes", "some", "ARRAY")
         )
     }
 

--- a/restdocs-openapi-gradle-plugin/build.gradle.kts
+++ b/restdocs-openapi-gradle-plugin/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     compile(kotlin("gradle-plugin"))
     compile(kotlin("stdlib-jdk8"))
 
+    implementation(project(":restdocs-openapi-model"))
     implementation(project(":restdocs-openapi-generator"))
     implementation("com.fasterxml.jackson.core:jackson-databind:2.9.5")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.5")

--- a/restdocs-openapi-gradle-plugin/src/main/kotlin/com/epages/restdocs/openapi/gradle/RestdocsOpenApiPluginExtension.kt
+++ b/restdocs-openapi-gradle-plugin/src/main/kotlin/com/epages/restdocs/openapi/gradle/RestdocsOpenApiPluginExtension.kt
@@ -1,6 +1,6 @@
 package com.epages.restdocs.openapi.gradle
 
-import com.epages.restdocs.openapi.generator.Oauth2Configuration
+import com.epages.restdocs.openapi.model.Oauth2Configuration
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.readValue

--- a/restdocs-openapi-gradle-plugin/src/main/kotlin/com/epages/restdocs/openapi/gradle/RestdocsOpenApiTask.kt
+++ b/restdocs-openapi-gradle-plugin/src/main/kotlin/com/epages/restdocs/openapi/gradle/RestdocsOpenApiTask.kt
@@ -2,7 +2,7 @@ package com.epages.restdocs.openapi.gradle
 
 import com.epages.restdocs.openapi.generator.ApiSpecificationWriter
 import com.epages.restdocs.openapi.generator.OpenApi20Generator
-import com.epages.restdocs.openapi.generator.ResourceModel
+import com.epages.restdocs.openapi.model.ResourceModel
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue

--- a/restdocs-openapi-model/build.gradle.kts
+++ b/restdocs-openapi-model/build.gradle.kts
@@ -1,0 +1,17 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    mavenCentral()
+    jcenter()
+    maven { url = uri("https://jitpack.io") }
+}
+
+dependencies {
+    compile(kotlin("stdlib-jdk8"))
+}
+
+

--- a/restdocs-openapi-model/src/main/kotlin/com/epages/restdocs/openapi/model/Oauth2Configuration.kt
+++ b/restdocs-openapi-model/src/main/kotlin/com/epages/restdocs/openapi/model/Oauth2Configuration.kt
@@ -1,4 +1,4 @@
-package com.epages.restdocs.openapi.generator
+package com.epages.restdocs.openapi.model
 
 open class Oauth2Configuration(
     var tokenUrl: String = "", // required for types "password", "application", "accessCode"

--- a/restdocs-openapi-model/src/main/kotlin/com/epages/restdocs/openapi/model/ResourceModel.kt
+++ b/restdocs-openapi-model/src/main/kotlin/com/epages/restdocs/openapi/model/ResourceModel.kt
@@ -1,4 +1,4 @@
-package com.epages.restdocs.openapi.generator
+package com.epages.restdocs.openapi.model
 
 data class ResourceModel(
     val operationId: String,

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = 'restdocs-openapi-parent'
 include 'restdocs-openapi'
+include 'restdocs-openapi-model'
 include 'restdocs-openapi-generator'
 include 'restdocs-openapi-gradle-plugin'
 include 'restdocs-openapi-sample'


### PR DESCRIPTION
This will allow 3rd parties to write additional "generators" using the same `resource.json` files that this project produces.