### PR TITLE
Support operation name placeholders

### DIFF
--- a/restdocs-openapi/src/test/kotlin/com/epages/restdocs/openapi/OperationBuilder.kt
+++ b/restdocs-openapi/src/test/kotlin/com/epages/restdocs/openapi/OperationBuilder.kt
@@ -41,6 +41,10 @@ class OperationBuilder {
 
     private lateinit var outputDirectory: File
 
+    private var testClass: Class<*>? = null
+
+    private var testMethodName: String? = null
+
     private val templateFormat = TemplateFormats.asciidoctor()
 
     private var requestBuilder: OperationRequestBuilder? = null
@@ -65,6 +69,16 @@ class OperationBuilder {
 
     fun attribute(name: String, value: Any): OperationBuilder {
         this.attributes[name] = value
+        return this
+    }
+
+    fun testClass(testClass: Class<*>): OperationBuilder {
+        this.testClass = testClass
+        return this
+    }
+
+    fun testMethodName(testMethodName: String): OperationBuilder {
+        this.testMethodName = testMethodName
         return this
     }
 
@@ -109,7 +123,7 @@ class OperationBuilder {
         val manualRestDocumentation = ManualRestDocumentation(
             this.outputDirectory.absolutePath
         )
-        manualRestDocumentation.beforeTest(null, null)
+        manualRestDocumentation.beforeTest(this.testClass, this.testMethodName)
         return manualRestDocumentation.beforeOperation()
     }
 


### PR DESCRIPTION
Currently, if you use operation name place holders like `{class-name}` and `{method-name}` the place holders are not replaced with the actual values in the `operationId` property of the `resource.json` file. This results in an invalid specification being produced since all the operation IDs will be the same and they need to be unique.

This change fixes `ResourceSnippet` so that it properly replaces the place holders when building the resource model.