### PR TITLE
Improvements to wrapper API

### DIFF
--- a/restdocs-openapi/src/main/kotlin/com/epages/restdocs/openapi/ResourceSnippetParameters.kt
+++ b/restdocs-openapi/src/main/kotlin/com/epages/restdocs/openapi/ResourceSnippetParameters.kt
@@ -134,15 +134,27 @@ class ParameterDescriptorWithType(val name: String) : IgnorableDescriptor<Parame
     }
 }
 
-class ResourceSnippetParametersBuilder {
+abstract class ResourceSnippetDetails {
     var summary: String? = null
-        private set
+        protected set
     var description: String? = null
-        private set
+        protected set
     var privateResource: Boolean = false
-        private set
+        protected set
     var deprecated: Boolean = false
-        private set
+        protected set
+    var tags: Set<String> = setOf()
+        protected set
+
+    abstract fun summary(summary: String?): ResourceSnippetDetails
+    abstract fun description(description: String?): ResourceSnippetDetails
+    abstract fun privateResource(privateResource: Boolean): ResourceSnippetDetails
+    abstract fun deprecated(deprecated: Boolean): ResourceSnippetDetails
+    abstract fun tag(tag: String): ResourceSnippetDetails
+    abstract fun tags(vararg tags: String): ResourceSnippetDetails
+}
+
+class ResourceSnippetParametersBuilder : ResourceSnippetDetails() {
     var requestFields: List<FieldDescriptor> = emptyList()
         private set
     var responseFields: List<FieldDescriptor> = emptyList()
@@ -157,13 +169,11 @@ class ResourceSnippetParametersBuilder {
         private set
     var responseHeaders: List<HeaderDescriptorWithType> = emptyList()
         private set
-    var tags: Set<String> = setOf()
-        private set
 
-    fun summary(summary: String?) = apply { this.summary = summary }
-    fun description(description: String?) = apply { this.description = description }
-    fun privateResource(privateResource: Boolean) = apply { this.privateResource = privateResource }
-    fun deprecated(deprecated: Boolean) = apply { this.deprecated = deprecated }
+    override fun summary(summary: String?) = apply { this.summary = summary }
+    override fun description(description: String?) = apply { this.description = description }
+    override fun privateResource(privateResource: Boolean) = apply { this.privateResource = privateResource }
+    override fun deprecated(deprecated: Boolean) = apply { this.deprecated = deprecated }
 
     fun requestFields(vararg requestFields: FieldDescriptor) = requestFields(requestFields.toList())
     fun requestFields(requestFields: List<FieldDescriptor>) = apply { this.requestFields = requestFields }
@@ -199,8 +209,9 @@ class ResourceSnippetParametersBuilder {
     fun responseHeaders(vararg responseHeaders: HeaderDescriptorWithType) = responseHeaders(responseHeaders.toList())
     fun responseHeaders(vararg responseHeaders: HeaderDescriptor) = responseHeaders(
         responseHeaders.map { HeaderDescriptorWithType.fromHeaderDescriptor(it) })
-    fun tag(tag: String) = tags(tag)
-    fun tags(vararg tags: String) = apply { this.tags += tags }
+
+    override fun tag(tag: String) = tags(tag)
+    override fun tags(vararg tags: String) = apply { this.tags += tags }
 
     fun build() = ResourceSnippetParameters(
         summary,

--- a/restdocs-openapi/src/test/kotlin/com/epages/restdocs/openapi/MockMvcRestDocumentationWrapperIntegrationTest.kt
+++ b/restdocs-openapi/src/test/kotlin/com/epages/restdocs/openapi/MockMvcRestDocumentationWrapperIntegrationTest.kt
@@ -59,6 +59,15 @@ class MockMvcRestDocumentationWrapperIntegrationTest(@Autowired mockMvc: MockMvc
         assertThatCode { this.whenDocumentedWithAllFieldsLinksIgnored() }.doesNotThrowAnyException()
     }
 
+    @Test
+    fun should_document_restdocs_and_resource_snippet_details() {
+        givenEndpointInvoked()
+
+        whenDocumentedWithResourceSnippetDetails()
+
+        thenSnippetFileExists()
+    }
+
     @Throws(Exception::class)
     private fun whenDocumentedWithRestdocsAndResource() {
         resultActions
@@ -137,6 +146,36 @@ class MockMvcRestDocumentationWrapperIntegrationTest(@Autowired mockMvc: MockMvc
                 MockMvcRestDocumentationWrapper.document(
                     identifier = operationName,
                     privateResource = true,
+                    requestPreprocessor = operationRequestPreprocessor,
+                    snippets = *arrayOf(
+                        requestFields(fieldDescriptors().fieldDescriptors),
+                        responseFields(
+                            fieldWithPath("comment").description("the comment"),
+                            fieldWithPath("flag").description("the flag"),
+                            fieldWithPath("count").description("the count"),
+                            fieldWithPath("id").description("id"),
+                            subsectionWithPath("_links").ignored()
+                        ),
+                        links(
+                            linkWithRel("self").description("some"),
+                            linkWithRel("multiple").description("multiple")
+                        )
+                    )
+                )
+            )
+    }
+
+    @Throws(Exception::class)
+    private fun whenDocumentedWithResourceSnippetDetails() {
+        val operationRequestPreprocessor = OperationRequestPreprocessor { r -> r }
+        resultActions
+            .andDo(
+                MockMvcRestDocumentationWrapper.document(
+                    identifier = operationName,
+                    resourceDetails = MockMvcRestDocumentationWrapper.resourceDetails()
+                        .description("The Resource")
+                        .privateResource(true)
+                        .tag("some-tag"),
                     requestPreprocessor = operationRequestPreprocessor,
                     snippets = *arrayOf(
                         requestFields(fieldDescriptors().fieldDescriptors),


### PR DESCRIPTION
Currently, the `MockMvcRestDocumentationWrapper` provides various overloaded `document` methods that allow you to pass in details needed for building the resource model like `description`, `summary`, `privateResource`, `deprecated`, etc.  This works fine but it can be difficult to read when using all the parameters.

For instance:

```java
  document(
    "get-book-by-id",
    "Get book by id",
    true,
    false,
    responseFields(
      fieldWithPath("title").description("the title of the book"),
      fieldWithPath("author").description("the author of the book")
    )
  )
```

In that example, it's not clear that `true` refers to the `privateResource` flag and `false` refers to the `deprecated` flag.

Another issue is that some parameters on `ResourceSnippetParameters` are not available to be set, like `tags`.  We could add them to the overloaded methods but that would just make the above problem worse.

This pull requests adds the ability to just provide a `ResourceSnippetDetails` object which is a subset of `ResourceSnippetParametersBuilder`. This allows us to change the above example to the following:

```java
  document(
    "get-book-by-id",
    resource()
      .description("Get book by id")
      .privateResource(true)
      .deprecated(false)
      .tag("book"),
    responseFields(
      fieldWithPath("title").description("the title of the book"),
      fieldWithPath("author").description("the author of the book")
    )
  )
```