### PR TITLE
Fix Gradle plugin publishing by adding explicit dependency versions for POM generation

### DIFF
--- a/restdocs-api-spec-gradle-plugin/build.gradle.kts
+++ b/restdocs-api-spec-gradle-plugin/build.gradle.kts
@@ -49,17 +49,13 @@ pluginBundle {
 val jacocoRuntime by configurations.creating
 
 dependencies {
-    compileOnly(gradleKotlinDsl())
-
-    implementation(kotlin("gradle-plugin"))
-    implementation(kotlin("stdlib-jdk8"))
 
     implementation(project(":restdocs-api-spec-openapi-generator"))
     implementation(project(":restdocs-api-spec-openapi3-generator"))
     implementation(project(":restdocs-api-spec-postman-generator"))
-    implementation("tools.jackson.core:jackson-databind")
-    implementation("tools.jackson.module:jackson-module-kotlin")
-    implementation("tools.jackson.dataformat:jackson-dataformat-yaml")
+    implementation("tools.jackson.core:jackson-databind:3.0.2")
+    implementation("tools.jackson.module:jackson-module-kotlin:3.0.2")
+    implementation("tools.jackson.dataformat:jackson-dataformat-yaml:3.0.2")
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/restdocs-api-spec-jsonschema/build.gradle.kts
+++ b/restdocs-api-spec-jsonschema/build.gradle.kts
@@ -18,11 +18,10 @@ the<DependencyManagementExtension>().apply {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
     implementation(project(":restdocs-api-spec-model"))
     implementation("com.github.erosb:everit-json-schema:1.11.0")
-    implementation("tools.jackson.core:jackson-databind")
-    implementation("tools.jackson.module:jackson-module-kotlin")
+    implementation("tools.jackson.core:jackson-databind:3.0.2")
+    implementation("tools.jackson.module:jackson-module-kotlin:3.0.2")
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/restdocs-api-spec-mockmvc/build.gradle.kts
+++ b/restdocs-api-spec-mockmvc/build.gradle.kts
@@ -18,7 +18,6 @@ the<DependencyManagementExtension>().apply {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
 
     api(project(":restdocs-api-spec"))
     implementation("org.springframework.restdocs:spring-restdocs-mockmvc")

--- a/restdocs-api-spec-model/build.gradle.kts
+++ b/restdocs-api-spec-model/build.gradle.kts
@@ -18,7 +18,6 @@ the<DependencyManagementExtension>().apply {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
     implementation("com.fasterxml.jackson.core:jackson-annotations")
 }
 

--- a/restdocs-api-spec-openapi-generator/build.gradle.kts
+++ b/restdocs-api-spec-openapi-generator/build.gradle.kts
@@ -18,15 +18,14 @@ the<DependencyManagementExtension>().apply {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
 
     api(project(":restdocs-api-spec-model"))
     api(project(":restdocs-api-spec-jsonschema"))
     api("io.swagger:swagger-core:1.6.16")
     implementation("org.springframework.boot:spring-boot-jackson2")
-    implementation("tools.jackson.core:jackson-databind")
-    implementation("tools.jackson.module:jackson-module-kotlin")
-    implementation("tools.jackson.dataformat:jackson-dataformat-yaml")
+    implementation("tools.jackson.core:jackson-databind:3.0.2")
+    implementation("tools.jackson.module:jackson-module-kotlin:3.0.2")
+    implementation("tools.jackson.dataformat:jackson-dataformat-yaml:3.0.2")
 
     testImplementation("io.swagger:swagger-parser:1.0.75")
     testImplementation("org.junit.jupiter:junit-jupiter-engine")

--- a/restdocs-api-spec-openapi3-generator/build.gradle.kts
+++ b/restdocs-api-spec-openapi3-generator/build.gradle.kts
@@ -18,15 +18,14 @@ the<DependencyManagementExtension>().apply {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
 
     api(project(":restdocs-api-spec-model"))
     api(project(":restdocs-api-spec-jsonschema"))
 
     api("io.swagger.core.v3:swagger-core:2.2.37")
-    implementation("tools.jackson.core:jackson-databind")
-    implementation("tools.jackson.module:jackson-module-kotlin")
-    implementation("tools.jackson.dataformat:jackson-dataformat-yaml")
+    implementation("tools.jackson.core:jackson-databind:3.0.2")
+    implementation("tools.jackson.module:jackson-module-kotlin:3.0.2")
+    implementation("tools.jackson.dataformat:jackson-dataformat-yaml:3.0.2")
     implementation("org.springframework.boot:spring-boot-jackson2")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 

--- a/restdocs-api-spec-postman-generator/build.gradle.kts
+++ b/restdocs-api-spec-postman-generator/build.gradle.kts
@@ -18,11 +18,10 @@ the<DependencyManagementExtension>().apply {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
 
     implementation(project(":restdocs-api-spec-model"))
-    implementation("tools.jackson.core:jackson-databind")
-    implementation("tools.jackson.module:jackson-module-kotlin")
+    implementation("tools.jackson.core:jackson-databind:3.0.2")
+    implementation("tools.jackson.module:jackson-module-kotlin:3.0.2")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.springframework.boot:spring-boot-jackson2")
 

--- a/restdocs-api-spec-webtestclient/build.gradle.kts
+++ b/restdocs-api-spec-webtestclient/build.gradle.kts
@@ -18,7 +18,6 @@ the<DependencyManagementExtension>().apply {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
 
     implementation(project(":restdocs-api-spec"))
     implementation("org.springframework.restdocs:spring-restdocs-webtestclient")

--- a/restdocs-api-spec/build.gradle.kts
+++ b/restdocs-api-spec/build.gradle.kts
@@ -20,14 +20,13 @@ the<DependencyManagementExtension>().apply {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("reflect"))
 
     implementation("org.springframework.restdocs:spring-restdocs-core")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("tools.jackson.core:jackson-databind")
-    implementation("tools.jackson.module:jackson-module-kotlin")
+    implementation("tools.jackson.core:jackson-databind:3.0.2")
+    implementation("tools.jackson.module:jackson-module-kotlin:3.0.2")
     implementation("com.samskivert:jmustache:$jmustacheVersion")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")


### PR DESCRIPTION
This change fixes a failure during the publishPlugins task when releasing the Gradle plugin.

The Gradle Plugin Publish plugin generates its own POM when pluginBundle.mavenCoordinates() is used. In that mode it requires explicit dependency versions. Several dependencies in the Gradle plugin module relied on versions provided indirectly via the Spring Boot BOM (io.spring.dependency-management). While this works for compilation, the plugin-publish process cannot resolve these versions when generating the plugin POM.

As a result, the release failed with errors like:
```
No version found for ... on pom generation
```

This PR adds explicit dependency versions so that the plugin publication can generate a complete POM and the release pipeline succeeds.