### PR TITLE
Declare spring-boot-jackson2 same as Spring Boot version (issue  #293)

### DIFF
--- a/restdocs-api-spec-openapi-generator/build.gradle.kts
+++ b/restdocs-api-spec-openapi-generator/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
     api(project(":restdocs-api-spec-model"))
     api(project(":restdocs-api-spec-jsonschema"))
     api("io.swagger:swagger-core:1.6.16")
-    implementation("org.springframework.boot:spring-boot-jackson2")
+    implementation("org.springframework.boot:spring-boot-jackson2:4.0.5")
     implementation("tools.jackson.core:jackson-databind:3.0.2")
     implementation("tools.jackson.module:jackson-module-kotlin:3.0.2")
     implementation("tools.jackson.dataformat:jackson-dataformat-yaml:3.0.2")

--- a/restdocs-api-spec-openapi3-generator/build.gradle.kts
+++ b/restdocs-api-spec-openapi3-generator/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     implementation("tools.jackson.core:jackson-databind:3.0.2")
     implementation("tools.jackson.module:jackson-module-kotlin:3.0.2")
     implementation("tools.jackson.dataformat:jackson-dataformat-yaml:3.0.2")
-    implementation("org.springframework.boot:spring-boot-jackson2")
+    implementation("org.springframework.boot:spring-boot-jackson2:4.0.5")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     testImplementation("io.swagger.parser.v3:swagger-parser:2.1.34")

--- a/restdocs-api-spec-postman-generator/build.gradle.kts
+++ b/restdocs-api-spec-postman-generator/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation("tools.jackson.core:jackson-databind:3.0.2")
     implementation("tools.jackson.module:jackson-module-kotlin:3.0.2")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("org.springframework.boot:spring-boot-jackson2")
+    implementation("org.springframework.boot:spring-boot-jackson2:4.0.5")
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")


### PR DESCRIPTION
This should fix https://github.com/ePages-de/restdocs-api-spec/issues/293