### PR TITLE
fix: make ApiSpecTask compatible with Gradle Configuration Cache

### DIFF
--- a/restdocs-api-spec-gradle-plugin/src/main/kotlin/com/epages/restdocs/apispec/gradle/ApiSpecTask.kt
+++ b/restdocs-api-spec-gradle-plugin/src/main/kotlin/com/epages/restdocs/apispec/gradle/ApiSpecTask.kt
@@ -6,7 +6,6 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import tools.jackson.databind.DeserializationFeature
 import tools.jackson.module.kotlin.jacksonMapperBuilder
-import tools.jackson.module.kotlin.jacksonObjectMapper
 import tools.jackson.module.kotlin.readValue
 import java.io.File
 
@@ -29,8 +28,6 @@ abstract class ApiSpecTask : DefaultTask() {
     private val snippetsDirectoryFile
         get() = project.file(snippetsDirectory)
 
-    private val objectMapper = jacksonMapperBuilder().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).build()
-
     open fun applyExtension(extension: ApiSpecExtension) {
         outputDirectory = extension.outputDirectory
         snippetsDirectory = extension.snippetsDirectory
@@ -40,6 +37,8 @@ abstract class ApiSpecTask : DefaultTask() {
 
     @TaskAction
     fun aggregateResourceModels() {
+        val objectMapper = jacksonMapperBuilder().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).build()
+
         val resourceModels =
             snippetsDirectoryFile
                 .walkTopDown()


### PR DESCRIPTION
## Summary

Move `objectMapper` instantiation from a task instance field into the `@TaskAction` method to make `OpenApi3Task`, `OpenApiTask`, and `PostmanTask` compatible with Gradle's [Configuration Cache](https://docs.gradle.org/current/userguide/configuration_cache.html).

## Problem

Jackson's `ObjectMapper` contains non-serializable fields (`StdDateFormat`, `ReentrantLock`) that prevent Gradle from serializing the task graph into the configuration cache. This causes:

```
Configuration cache state could not be cached: field `_dateFormat` of
`com.fasterxml.jackson.databind.cfg.BaseSettings` bean found in field `objectMapper`
of task `:generateOpenApi3Raw` of type `com.epages.restdocs.apispec.gradle.OpenApi3Task`:
error writing value of type 'com.fasterxml.jackson.databind.util.StdDateFormat'
```

Every build that includes these tasks gets its configuration cache entry discarded, negating any caching benefit.

## Fix

Since `objectMapper` is only used inside `aggregateResourceModels()`, it does not need to be a persistent field on the task instance. Moving it to a local variable inside the `@TaskAction` method avoids the serialization issue entirely.

Fixes #284